### PR TITLE
fix(JAQPOT-208): update jaqpotpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.111.0
 pydantic==2.7.1
 uvicorn==0.29.0
-jaqpotpy==6.2.0
+jaqpotpy==6.2.1


### PR DESCRIPTION
Missing dependency compress pickle cause jaqpotpy is not updated