### PR TITLE
fix: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish Docker image
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/ntua-unit-of-control-and-informatics/jaqpotpy-inference/security/code-scanning/4](https://github.com/ntua-unit-of-control-and-informatics/jaqpotpy-inference/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow does not appear to require write access to the repository or other elevated permissions, we will set the permissions to `contents: read`, which is the minimal level required for most workflows. This ensures the `GITHUB_TOKEN` has restricted access, adhering to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow, applying to all jobs within the workflow. This avoids redundancy and ensures consistent permissions across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
